### PR TITLE
Revert "Remove unused color-name dependency"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.10",
+        "color-name": "^2.0.0",
         "color-parse": "^2.0.2",
         "color-rgba": "^3.0.0",
         "color-space": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.10",
+    "color-name": "^2.0.0",
     "color-parse": "^2.0.2",
     "color-rgba": "^3.0.0",
     "color-space": "^2.3.1",

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,7 @@ const addNodeModulesToDist = () => {
         ['./node_modules/ol', './dist/node_modules/ol'],
         ['./node_modules/color-rgba', './dist/node_modules/color-rgba'],
         ['./node_modules/color-parse', './dist/node_modules/color-parse'],
+        ['./node_modules/color-name', './dist/node_modules/color-name'],
         ['./node_modules/color-space', './dist/node_modules/color-space'],
         ['./node_modules/rbush', './dist/node_modules/rbush'],
         ['./node_modules/quickselect', './dist/node_modules/quickselect'],
@@ -56,6 +57,17 @@ const addNodeModulesToDist = () => {
             recursive: true,
           })
         )
+      );
+
+      // tweak color-name default export
+      const colorNamePath = './dist/node_modules/color-name/index.js';
+      const colorName = await fs.readFile(
+        './dist/node_modules/color-name/index.js',
+        'utf-8'
+      );
+      await fs.writeFile(
+        colorNamePath,
+        colorName.replace('module.exports = ', 'export default ')
       );
     },
   };


### PR DESCRIPTION
This reverts https://github.com/openlayers/bench/commit/6b5b4d280eaf68508552ce6b33b336482f511f89

The `color-name` dependency isn't required by OL in recent versions but it still necessary when running on an older version (e.g. 9.x), so we still need it as a dev dependency and in the deployed assets.